### PR TITLE
Add support for one time code flow

### DIFF
--- a/lib/omniauth/strategies/azure_oauth2.rb
+++ b/lib/omniauth/strategies/azure_oauth2.rb
@@ -64,14 +64,14 @@ module OmniAuth
         redirect_uri = request.params["redirect_uri"]
         return {} unless redirect_uri
 
-        {:redirect_uri => redirect_uri}
+        {redirect_uri: redirect_uri}
       end
 
       def custom_login_hint
         login_hint = request.params["login_hint"]
         return {} unless login_hint
 
-        {:login_hint => login_hint}
+        {login_hint: login_hint}
       end
 
       def token_params


### PR DESCRIPTION
# What
Marketing is implementing Azure signup directly from our marketing site `mode.com`. The current instance of Omniauth azure gem doesn't support this as it doesn't allow and forward many oAuth2 options like login_hint properly. This change adds support for custom redirect_uri and login_hint to allow external site login using Azure through Omniauth.


# Why
[PLG-414](https://modeanalytics.atlassian.net/browse/PLG-414)

# Steps to test this change

1. NA

# Checklist

- [X] I've requested a security review or do not require one (not sure? see [here](https://github.com/mode/eng-docs/blob/master/security/security-review/review-checklist.md))
- [X] I've made any necessary deployment or environment changes or do not require any
- [X] I've added new test coverage or believe existing test coverage of this change is sufficient
- [X] I don't think this PR can be broken into smaller but still meaningful PRs
- [X] I've conducted a self-review


[PLG-414]: https://modeanalytics.atlassian.net/browse/PLG-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ